### PR TITLE
[Spring-Jersey] Query param with multiple values seperated by comma in rest request

### DIFF
--- a/spring-jersey/src/main/java/org/milan/Application.java
+++ b/spring-jersey/src/main/java/org/milan/Application.java
@@ -3,6 +3,7 @@ package org.milan;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.milan.filter.PoweredByResponseFilter;
 import org.milan.resource.DateResource;
+import org.milan.resource.CustomResource;
 import org.milan.resource.MessageResource;
 import org.milan.resource.ProfileResource;
 import org.milan.resource.TestResource;
@@ -27,7 +28,8 @@ public class Application extends ResourceConfig {
         register(MessageResource.class);
         register(PoweredByResponseFilter.class);
         register(DateResource.class);
-        packages("org.milan.rest.messenger");
+        register(CustomResource.class);
+        packages("org.milan");
     }
 
 }

--- a/spring-jersey/src/main/java/org/milan/model/SortParams.java
+++ b/spring-jersey/src/main/java/org/milan/model/SortParams.java
@@ -1,0 +1,25 @@
+package org.milan.model;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Sorting params pojo
+ *
+ * @author Milan Rathod
+ */
+public class SortParams {
+
+    private List<String> sortParamList;
+
+    public SortParams(String commaSeparatedString) {
+        sortParamList = Arrays.stream(commaSeparatedString.split(","))
+                .map(String::valueOf)
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getSortParamList() {
+        return sortParamList;
+    }
+}

--- a/spring-jersey/src/main/java/org/milan/resource/CustomResource.java
+++ b/spring-jersey/src/main/java/org/milan/resource/CustomResource.java
@@ -1,0 +1,37 @@
+package org.milan.resource;
+
+import org.milan.model.SortParams;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+/**
+ * Custom resource for testing purpose
+ *
+ * @author Milan Rathod
+ */
+@Path("/custom")
+@Produces(MediaType.APPLICATION_JSON)
+public class CustomResource {
+
+    /**
+     * For given request i.e. custom?sort=sort1&sort=sort2
+     */
+    @GET
+    public List<String> getAllParamValues(@QueryParam("sort") List<String> sortOrders) {
+        return sortOrders;
+    }
+
+    /**
+     * For given request i.e. custom?sort=sort1,sort2,sort3
+     */
+    @GET
+    public List<String> getAllParamValuesV2(@QueryParam("sort") SortParams sortParams) {
+        return sortParams.getSortParamList();
+    }
+}


### PR DESCRIPTION
## Issue before the fix
1. Query param with multiple values separated by comma is not handled.
2. Query param with multiple values seperated by & is not handled.

## What changed
Added changes to handled both the use cases mentioned.